### PR TITLE
Auto save document 1 second after finishing typing

### DIFF
--- a/lib/notational-velocity-view.coffee
+++ b/lib/notational-velocity-view.coffee
@@ -1,5 +1,6 @@
 path = require 'path'
 fs = require 'fs-plus'
+_ = require 'underscore-plus'
 {$, $$, SelectListView} = require 'atom-space-pen-views'
 NoteDirectory = require './note-directory'
 Note = require './note'
@@ -98,11 +99,14 @@ class NotationalVelocityView extends SelectListView
 
     if filePath
       atom.workspace.open(filePath).then (editor) ->
+        save = ->
+          atom.packages.deactivatePackage 'whitespace'
+          console.log 'save'
+          editor.save()
+          atom.packages.activatePackage 'whitespace'
+        debouncedSave = _.debounce save, 1000
         editor.onDidStopChanging () ->
-          if editor.isModified()
-            atom.packages.deactivatePackage("whitespace");
-            editor.save()
-            atom.packages.activatePackage("whitespace");
+          debouncedSave() if editor.isModified()
 
     @cancel()
 

--- a/lib/notational-velocity-view.coffee
+++ b/lib/notational-velocity-view.coffee
@@ -101,7 +101,6 @@ class NotationalVelocityView extends SelectListView
       atom.workspace.open(filePath).then (editor) ->
         save = ->
           atom.packages.deactivatePackage 'whitespace'
-          console.log 'save'
           editor.save()
           atom.packages.activatePackage 'whitespace'
         debouncedSave = _.debounce save, 1000

--- a/lib/notational-velocity-view.coffee
+++ b/lib/notational-velocity-view.coffee
@@ -87,16 +87,24 @@ class NotationalVelocityView extends SelectListView
 
   confirmSelection: ->
     item = @getSelectedItem()
+    filePath = null
     if item?
-      atom.workspace.open(item.getFilePath())
-      @cancel()
+      filePath = item.getFilePath()
     else
       sanitizedQuery = @getFilterQuery().replace(/\s+$/, '')
       if sanitizedQuery.length > 0
         filePath = path.join(@rootDirectory, sanitizedQuery + '.md')
         fs.writeFileSync(filePath, '')
-        atom.workspace.open(filePath)
-      @cancel()
+
+    if filePath
+      atom.workspace.open(filePath).then (editor) ->
+        editor.onDidStopChanging () ->
+          if editor.isModified()
+            atom.packages.deactivatePackage("whitespace");
+            editor.save()
+            atom.packages.activatePackage("whitespace");
+
+    @cancel()
 
   destroy: ->
     @cancel()

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "fs-plus": "2.x",
     "atom-space-pen-views": "^2.0.3",
-    "pathwatcher": "^4.2"
+    "pathwatcher": "^4.2",
+    "underscore-plus": "^1.6.6"
   },
   "devDependencies": {
     "fs-plus": "2.x",


### PR DESCRIPTION
This uses [`editor.onDidStopChanging`](https://atom.io/docs/api/v0.198.0/TextEditor#instance-isModified) and [underscores `debounce` function](http://underscorejs.org/#debounce) to implement autosave functionality similar to that in Notational Velocity and NValt.

![](http://cl.ly/image/3x3Q2u332z3T/nv-autosave.gif)

I also [disable the whitespace plugin](https://github.com/seongjaelee/notational-velocity/compare/master...jonmagic:auto-save-on-did-stop-changing?expand=1#diff-102ce7d688a3e92e8fd508eced9b0414R103) during autosave so that it doesn't remove newlines when I'm trying to type.
