### PR TITLE
Add instructions for changing the cmd-l keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ We do believe Notational Velocity is the precursor of the famous note-taking app
 
 - `alt-cmd-l`: Toggles the search view.
 
+You can also override `cmd-l` if you want to keep your muscle memory from Notational Velocity and nvALT. Just edit your keymap (Atom menu -> Open Your Keymap) and add the following lines:
+
+```cson
+'atom-text-editor':
+  'cmd-l': 'unset!'
+'atom-workspace':
+  'cmd-l': 'notational-velocity:toggle'
+```
+
 ## References
 
 - [Notational Velocity](http://notational.net/)


### PR DESCRIPTION
I really want to keep the `cmd-l` keybinding that I'm used to in nvALT and I don't use that keybinding for selecting a line in Atom so this PR provides instructions for unbinding select line and rebinding `cmd-l` to Notational Velocity.
