### PR TITLE
Fix settings documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,16 @@ We do believe Notational Velocity is the precursor of the famous note-taking app
 To configure your note directory, set `notational-velocity.directory`:
 
 * Open your `~/.atom/config.cson` file from the menu: *Atom > Open Your Config*
-* Append the following lines, indented one step in from `*` at the top:
+* Append the following lines:
 
     ```cson
       'notational-velocity':
         directory: '/path/to/your/notes'
     ```
+
+The first line should be indented by one step from `*` at the top. If you've
+kept the default indentation of two spaces, the block above should paste in
+properly.
 
 Double-quotes also work.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We do believe Notational Velocity is the precursor of the famous note-taking app
 
 To configure your note directory, set `notational-velocity.directory`:
 
-* Open your `~/.atom/config.cson` file via *Atom > Open Your Config*
+* Open your `~/.atom/config.cson` file from the menu: *Atom > Open Your Config*
 * Append the following lines, indented one step in from `*` at the top:
 
     ```cson

--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ We do believe Notational Velocity is the precursor of the famous note-taking app
 
 ## Settings
 
-- `Note Directory`: The directory to archive notes.
+To configure your note directory, set `notational-velocity.directory`:
+
+* Open your `~/.atom/config.cson` file via *Atom > Open Your Config*
+* Append the following lines, indented one step in from `*` at the top:
+
+          'notational-velocity':
+            directory: '/path/to/your/notes'
+
+Double-quotes also work.
 
 ## Key Bindings
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ To configure your note directory, set `notational-velocity.directory`:
 * Open your `~/.atom/config.cson` file via *Atom > Open Your Config*
 * Append the following lines, indented one step in from `*` at the top:
 
-          'notational-velocity':
-            directory: '/path/to/your/notes'
+    ```cson
+      'notational-velocity':
+        directory: '/path/to/your/notes'
+    ```
 
 Double-quotes also work.
 


### PR DESCRIPTION
Fixes #15. Let me know if you want either:
1. `Atom menu -> Open Your Keymap` also fixed to match this and the [Atom Documentation](https://atom.io/docs/v0.186.0/customizing-atom)
2. `Atom > Open Your Config` fixed to match `Open Your Keymap` despite the Atom Documentation

Short-cut to result to make proof-reading easier: [Settings](https://github.com/garthk/notational-velocity/blob/fix-settings-documentation/README.md#settings)
