### PR TITLE
Use "chokidar" instead of "pathwatcher" to fix install errors on Windows

### DIFF
--- a/lib/note-directory.coffee
+++ b/lib/note-directory.coffee
@@ -1,6 +1,6 @@
 path = require 'path'
 fs = require 'fs-plus'
-pathWatcher = require 'pathwatcher'
+chokidar = require 'chokidar'
 Note = require './note'
 
 module.exports =
@@ -9,7 +9,7 @@ class NoteDirectory
     @directories = []
     @notes = []
     @updateMetadata()
-    @watcher = pathWatcher.watch(@filePath, (event) => @onChange(event))
+    @watcher = chokidar.watch(@filePath).on('all', (event) => @onChange(event))
 
   destroy: ->
     @notes.map (x) -> x.destroy()
@@ -52,7 +52,7 @@ class NoteDirectory
 
   onChange: (event) ->
     # For the case of rename and change, it will be handled in its parent.
-    if event == 'change'
+    if event in ['add', 'addDir', 'change']
       @updateMetadata()
       if @onChangeCallback != null
         @onChangeCallback()

--- a/lib/note.coffee
+++ b/lib/note.coffee
@@ -1,13 +1,13 @@
 path = require 'path'
 fs = require 'fs'
-pathWatcher = require 'pathwatcher'
+chokidar = require 'chokidar'
 
 module.exports =
 class Note
   constructor: (@filePath, @parent, @onChangeCallback) ->
     @updateMetadata()
     @updateText()
-    @watcher = pathWatcher.watch(@filePath, (event) => @onChange(event))
+    @watcher = chokidar.watch(@filePath).on('all', (event) => @onChange(event))
 
   destroy: ->
     @watcher.close()

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.1.0",
   "private": true,
   "contributors": [
-    "Seongjae Lee <seongjae@gmail.com>"
+    "Seongjae Lee <seongjae@gmail.com>",
+    "Nikita Litvin <deltaidea@derpy.ru>"
   ],
   "description": "Notational Velocity for Atom",
   "activationCommands": {

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   "dependencies": {
     "fs-plus": "2.x",
     "atom-space-pen-views": "^2.0.3",
-    "pathwatcher": "^4.2",
+    "chokidar": "^1.0.5",
     "underscore-plus": "^1.6.6"
   },
   "devDependencies": {
     "fs-plus": "2.x",
     "atom-space-pen-views": "^2.0.3",
-    "pathwatcher": "^4.2",
+    "chokidar": "^1.0.5",
     "underscore-plus": "^1.6.6",
     "temp": "~0.7.0"
   }

--- a/spec/note-directory-spec.coffee
+++ b/spec/note-directory-spec.coffee
@@ -1,7 +1,6 @@
 path = require 'path'
 fs = require 'fs-plus'
 temp = require 'temp'
-pathWatcher = require 'pathwatcher'
 NoteDirectory = require '../lib/note-directory'
 Note = require '../lib/note'
 
@@ -42,7 +41,7 @@ describe 'NoteDirectory.getNotes', ->
   afterEach ->
     noteDirectory.destroy()
     fs.unlinkSync(path.join(tempDirectory, 'Car', 'Mini.md'))
-    fs.rmdirSync(path.join(tempDirectory, 'Car'))
+    fs.removeSync(path.join(tempDirectory, 'Car'))
     fs.unlinkSync(path.join(tempDirectory, 'Readme.md'))
     atom.config.set('notational-velocity.directory', defaultDirectory)
 
@@ -114,4 +113,4 @@ describe 'NoteDirectory.getNotes', ->
       expect(notes[0].getText()).toBe 'milk'
       # So that it won't spit an error in the teardown stage.
       fs.unlinkSync(path.join(tempDirectory, 'Food', 'Milk.md'))
-      fs.rmdirSync(path.join(tempDirectory, 'Food'))
+      fs.removeSync(path.join(tempDirectory, 'Food'))

--- a/spec/note-spec.coffee
+++ b/spec/note-spec.coffee
@@ -1,7 +1,6 @@
 path = require 'path'
 fs = require 'fs-plus'
 temp = require 'temp'
-pathWatcher = require 'pathwatcher'
 Note = require '../lib/note'
 
 describe 'Note', ->


### PR DESCRIPTION
When installing the "pathwatcher" package on Windows, its dependency "runas" throws weird compilation errors.
- Replace "pathwatcher" with "chokidar".
- Call `onChange` for directories on "add", "addDir", and "change" events, which is equivalent to the "change" event in pathwatcher terms.
- Use `fs.removeSync` instead of `fs.rmdirSync` in tests - this fixes the tests.

Hopefully closes #21, closes #17.
