### PR TITLE
Normalize nvatom.directory so that ~/... works correctly.

### DIFF
--- a/lib/notational-velocity-view.coffee
+++ b/lib/notational-velocity-view.coffee
@@ -10,7 +10,7 @@ class NotationalVelocityView extends SelectListView
     @initializedAt = new Date()
     super
     @addClass('nvatom from-top overlay')
-    @rootDirectory = atom.config.get('nvatom.directory')
+    @rootDirectory = fs.normalize(atom.config.get('nvatom.directory'))
     unless fs.existsSync(@rootDirectory)
       throw new Error("The given directory #{@rootDirectory} does not exist. "
         + "Set the note directory to the existing one from Settings.")

--- a/lib/notational-velocity.coffee
+++ b/lib/notational-velocity.coffee
@@ -85,7 +85,7 @@ module.exports =
     @autosave(paneItem) for paneItem in atom.workspace.getPaneItems()
 
   ensureNoteDirectory: ->
-    noteDirectory = atom.config.get('nvatom.directory')
+    noteDirectory = fs.normalize(atom.config.get('nvatom.directory'))
     packagesDirectory = path.join(process.env.ATOM_HOME, 'packages')
     defaultNoteDirectory = path.join(packagesDirectory, 'nvatom', 'notebook')
 


### PR DESCRIPTION
I have my notes stored in `~/notes/nv` but I can't use that in my `config.cson` file because nvatom chokes on the `~` character. Using `fs.normalize()` resolves this issue.
